### PR TITLE
Separate logic from render with TPS limiter.

### DIFF
--- a/space.h
+++ b/space.h
@@ -1,20 +1,23 @@
 #pragma once
 #include "object.h"
 #include <vector>
+#include <mutex>
 #include <SFML/Graphics.hpp>
 
 class space{
 private:
 	sf::RenderWindow* window;
 	double zoom;
+    std::mutex planets_access_mutex;
 
 public:
 	std::vector<object> planets;
 
 private:
 	void process_all_planets();
-	void apply_changes();
-	void main_loop();
+	void draw_all_planets();
+	void render_event_loop();
+    void logic_loop();
 	void render_planet(object planet);
 public:
 	space(unsigned int number_of_planets);

--- a/space.h
+++ b/space.h
@@ -26,4 +26,6 @@ public:
 	void clear();
 	void generate(unsigned int number_of_planets);
 	void add_object(int, int, int, int, double, double);
+
+    float tps_limit_multipler = 1.0;
 };


### PR DESCRIPTION
Logic moved to separate thread with minimal synchronization with main (render & events) thread.
To avoid too big simulation speed I added 1000 TPS limit, it can be modified by changing multiplier (in public field of space class).